### PR TITLE
fix: Add ~/.var/app as a filesystem permission

### DIFF
--- a/org.kde.dolphin.json
+++ b/org.kde.dolphin.json
@@ -9,6 +9,7 @@
         "--filesystem=/media",
         "--filesystem=/run/media",
         "--filesystem=home",
+        "--filesystem=~/.var/app",
         "--share=ipc",
         "--share=network",
         "--socket=fallback-x11",


### PR DESCRIPTION
This is required for Dolphin to be able to see other flatpaks' files.