### PR TITLE
host as dolphin needs to access all of the filesystem

### DIFF
--- a/org.kde.dolphin.json
+++ b/org.kde.dolphin.json
@@ -6,9 +6,7 @@
     "command": "dolphin",
     "finish-args": [
         "--device=dri",
-        "--filesystem=/media",
-        "--filesystem=/run/media",
-        "--filesystem=home",
+        "--filesystem=host",
         "--filesystem=~/.var/app",
         "--share=ipc",
         "--share=network",


### PR DESCRIPTION
This aligns the manifest with the KDE GitLab one.