### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.dolphin.json
+++ b/org.kde.dolphin.json
@@ -27,12 +27,15 @@
         "--talk-name=org.kde.kuiserver"
     ],
     "cleanup": [
+        "/docs",
+        "/include",
         "/lib/cmake",
         "/lib/pkgconfig",
-        "/include",
-        "/docs",
+        "/man",
         "/mkspecs",
+        "/share/doc",
         "/share/man",
+        "/share/qlogging-categories6",
         "*.a",
         "*.la"
     ],


### PR DESCRIPTION
KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.

```
du -ha -d2

8,0K   ./man/man1
164K   ./man/man3
172K   ./man
15M    ./share/doc
44K    ./share/qlogging-categories6

```